### PR TITLE
Implement Shortcut Details and Setup

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -3,13 +3,13 @@ import 'framework7-icons';
 
 import './style.css';
 
-import {renderInputs, renderShortcut} from "~/render";
+import {renderDetails, renderInputs, renderShortcut} from "~/render";
 
 // @ts-ignore
 import {parse} from 'plist/dist/plist-parse.js';
 
 import Framework7 from 'framework7/lite/bundle';
-import {renderElement} from "~/element";
+import {renderClass, renderElement} from "~/element";
 
 let preview: HTMLDivElement | null;
 export let container: HTMLElement;
@@ -25,8 +25,7 @@ export function resetContainers() {
 }
 
 export function newContainer() {
-    const renderContainer = document.createElement('div');
-    renderContainer.className = 'sp-sub-container';
+    const renderContainer = renderClass('sp-sub-container')
     container.appendChild(renderContainer);
 
     containers.push(renderContainer);
@@ -67,6 +66,15 @@ export interface ShortcutData {
     WFWorkflowOutputContentItemClasses?: Array<String>
     WFQuickActionSurfaces?: Array<String>
     WFWorkflowTypes?: Array<String>
+    WFWorkflowImportQuestions?: Array<WFWorkflowImportQuestion>
+}
+
+interface WFWorkflowImportQuestion {
+    ActionIndex: number
+    Category: string
+    DefaultValue: string
+    ParameterKey: string
+    Text: string
 }
 
 interface ShortcutIcon {
@@ -194,9 +202,9 @@ export class ShortcutPreview {
         preview.innerHTML = '';
 
         if (this.header) {
-            const header = renderElement('div', {className: 'sp-header'});
+            const header = renderClass('sp-header');
 
-            const icon = renderElement('div', {className: 'shortcut-icon s64'});
+            const icon = renderClass('shortcut-icon s64');
             if (this.data.WFWorkflowIcon) {
                 const iconColor: number = this.data.WFWorkflowIcon.WFWorkflowIconStartColor;
                 const iconGlyph: number = this.data.WFWorkflowIcon.WFWorkflowIconGlyphNumber;
@@ -220,12 +228,13 @@ export class ShortcutPreview {
             preview.appendChild(header);
         }
 
-        container = renderElement('div', {className: 'sp-container ios'});
+        container = renderClass('sp-container ios');
 
         containers = [];
         containers.push(container);
 
         if (this.meta) {
+            renderDetails(this.data)
             renderInputs(this.data);
         }
 

--- a/src/render.ts
+++ b/src/render.ts
@@ -565,12 +565,11 @@ export function renderSegmentedControl(buttons: Array<SegmentedButton>) {
             className: 'button tab-link',
             innerText: props.text
         })
-        // @ts-ignore
-        if (Number(i) === 0) {
+        if (i === "0") {
             button.classList.add('button-active');
         }
         button.onclick = () => {
-            segmented.querySelectorAll('button')?.forEach(b => b.classList.remove('button-active'));
+            segmented.querySelectorAll('a')?.forEach(b => b.classList.remove('button-active'));
             button.classList.add('button-active');
         };
         segmented.appendChild(button);

--- a/src/render.ts
+++ b/src/render.ts
@@ -452,15 +452,16 @@ export function renderDetails(shortcut: ShortcutData): void {
                         },
                     ]),
                 ),
-                renderElement('div', {
-                    className: 'tab',
-                    id: 'tab-details'
-                }, ...renderDetailsTab(shortcut)),
-                renderElement('div', {
-                    className: 'tab',
-                    id: 'tab-setup',
-                    style: 'display:none'
-                }, ...renderSetupTab(shortcut)),
+                renderClass('tabs',
+                    renderElement('div', {
+                        className: 'tab tab-active',
+                        id: 'tab-details'
+                    }, ...renderDetailsTab(shortcut)),
+                    renderElement('div', {
+                        className: 'tab',
+                        id: 'tab-setup',
+                    }, ...renderSetupTab(shortcut)),
+                ),
             )
         ),
     ))
@@ -573,8 +574,9 @@ export function renderSegmentedControl(buttons: Array<SegmentedButton>) {
     const segmented = renderElement('p', {className: 'segmented segmented-strong'});
     for (const i in buttons) {
         const props = buttons[i];
-        const button = renderElement('button', {
-            className: 'button',
+        const button = renderElement('a', {
+            href: '#tab-' + props.text.toLowerCase(),
+            className: 'button tab-link',
             innerText: props.text
         })
         // @ts-ignore

--- a/src/render.ts
+++ b/src/render.ts
@@ -9,7 +9,7 @@ import {
     ShortcutData
 } from "~/main";
 import {ActionDefinition, actions, actionText} from "~/actions";
-import {renderValue} from "~/value";
+import {renderUnstyledValue, renderValue} from "~/value";
 import {DictionaryItem} from "~/actions/dictionary";
 import {renderClass, renderElement, renderText} from "~/element";
 import {Colors} from "~/colors";
@@ -236,10 +236,17 @@ export function renderList(...content: HTMLElement[]): HTMLElement {
     )
 }
 
+export function renderInsetList(...content: HTMLElement[]): HTMLElement {
+    return renderClass('list list-strong inset list-dividers',
+        renderElement('ul', {}, ...content)
+    )
+}
+
 export function renderListItem(image?: HTMLElement | string | null, title?: HTMLElement | string, after?: HTMLElement | string): HTMLElement {
     const item = document.createElement('li');
     const content = document.createElement('div');
     content.className = 'item-content';
+    content.style.alignItems = 'baseline';
 
     if (image) {
         const media = document.createElement('div');
@@ -258,11 +265,14 @@ export function renderListItem(image?: HTMLElement | string | null, title?: HTML
         const inner = document.createElement('div');
         inner.className = 'item-inner';
         if (title) {
-            const titleText = document.createElement('div');
-            titleText.className = 'item-title';
-            // @ts-ignore
-            titleText.innerHTML = title.innerHTML ?? title;
-            inner.appendChild(titleText);
+            if (title instanceof HTMLElement) {
+                inner.appendChild(title);
+            } else {
+                const titleText = document.createElement('div');
+                titleText.className = 'item-title';
+                titleText.innerHTML = title;
+                inner.appendChild(titleText)
+            }
         }
         if (after) {
             const afterText = document.createElement('div');
@@ -389,6 +399,201 @@ export function renderInputs(shortcut: ShortcutData) {
     card.innerHTML = renderCardContent(render).outerHTML;
 
     container.appendChild(card);
+}
+
+function toggleModal() {
+    const modal = document.querySelector('.sp-modal') as HTMLElement;
+    if (modal) {
+        modal.style.display = modal.style.display === 'none' ? 'flex' : 'none';
+    }
+}
+
+function toggleTab(id: string) {
+    const tabs = document.querySelectorAll('div.tab') as NodeListOf<HTMLElement>;
+    if (tabs) {
+        tabs.forEach(t => t.style.display = 'none');
+    }
+    const tab = document.querySelector('div.tab#tab-' + id) as HTMLElement;
+    if (tab) {
+        tab.style.display = 'block';
+    }
+}
+
+export function renderDetails(shortcut: ShortcutData): void {
+    container.appendChild(renderElement('div', {},
+        renderElement('div', {
+                className: 'link text-color-blue sp-open-details',
+                onclick: toggleModal,
+                ariaLabel: 'View Shortcut Details',
+                title: 'Shortcut Details',
+            },
+            renderInlineIcon('info_circle'),
+        ),
+
+        renderClass('sp-modal',
+            renderClass('sp-modal-content',
+                renderElement('div', {style: 'margin:1rem'},
+                    renderElement('div', {style: 'text-align:right'},
+                        renderElement('div', {
+                                className: 'link text-color-blue',
+                                onclick: toggleModal,
+                            },
+                            renderInlineIcon('xmark'),
+                        ),
+                    ),
+                    renderSegmentedControl([
+                        {
+                            text: 'Details',
+                            onclick: () => toggleTab('details'),
+                        },
+                        {
+                            text: 'Setup',
+                            onclick: () => toggleTab('setup'),
+                        },
+                    ]),
+                ),
+                renderElement('div', {
+                    className: 'tab',
+                    id: 'tab-details'
+                }, ...renderDetailsTab(shortcut)),
+                renderElement('div', {
+                    className: 'tab',
+                    id: 'tab-setup',
+                    style: 'display:none'
+                }, ...renderSetupTab(shortcut)),
+            )
+        ),
+    ))
+}
+
+function renderDetailsTab(shortcut: ShortcutData): HTMLElement[] {
+    return [
+        renderInsetList(
+            renderListItem(renderActionIcon('square_arrow_up', 'white', Colors.Blue), 'Show in Share Sheet',
+                renderValue(shortcut.WFWorkflowTypes ?
+                    shortcut.WFWorkflowTypes.includes(workflows.ActionExtension) : false)
+            ),
+        ),
+        renderBlockHeader('Mac'),
+        renderInsetList(
+            renderListItem(renderActionIcon('macwindow', 'white', Colors.Gray), 'Pin in Menu Bar',
+                renderValue(shortcut.WFWorkflowTypes ?
+                    shortcut.WFWorkflowTypes.includes(workflows.MenuBar) : false)
+            ),
+            renderListItem(renderActionIcon('doc_text_viewfinder', 'white', Colors.Red), 'Receive What\'s On Screen',
+                renderValue(shortcut.WFWorkflowTypes ?
+                    shortcut.WFWorkflowTypes.includes(workflows.ReceivesOnScreenContent) : false)
+            ),
+            renderListItem(renderActionIcon('gear_alt_fill', 'white', Colors.Gray), 'Use as a Quick Action',
+                renderValue(shortcut.WFWorkflowTypes ?
+                    shortcut.WFWorkflowTypes.includes(workflows.QuickActions) : false)
+            ),
+            renderActionContent(
+                renderListItem(null, 'Finder',
+                    renderValue(shortcut.WFQuickActionSurfaces ?
+                        shortcut.WFQuickActionSurfaces.includes(quickActions.Finder) : false)
+                ),
+                renderListItem(null, 'Services Menu',
+                    renderValue(shortcut.WFQuickActionSurfaces ?
+                        shortcut.WFQuickActionSurfaces.includes(quickActions.Finder) : false)
+                )
+            )
+        ),
+        renderBlockHeader('Apple Watch'),
+        renderInsetList(
+            renderListItem(null, 'Show on Apple Watch',
+                renderValue(shortcut.WFWorkflowTypes ?
+                    shortcut.WFWorkflowTypes.includes(workflows.QuickActions) : false)
+            ),
+        )
+    ];
+}
+
+export function renderBlockHeader(header: string): HTMLElement {
+    return renderElement('div', {
+        className: 'block-header',
+        innerText: header.toUpperCase(),
+        style: 'text-align:left'
+    })
+}
+
+function renderSetupTab(shortcut: ShortcutData): HTMLElement[] {
+    let questions: HTMLElement[] = [];
+    if (shortcut.WFWorkflowActions && shortcut.WFWorkflowImportQuestions) {
+        for (let question of shortcut.WFWorkflowImportQuestions) {
+            const shortcutAction = shortcut.WFWorkflowActions[question.ActionIndex]
+            if (shortcutAction) {
+                const identifier = shortcutAction.WFWorkflowActionIdentifier.replace('is.workflow.actions.', '');
+                const action = actions[identifier]
+
+                questions.push(renderListItem(
+                    renderActionIcon(action.icon, action.color, action.background),
+                    renderElement('div', {style: 'text-align: left'},
+                        renderElement('div', {className: 'item-title-row'},
+                            renderElement('div', {
+                                className: 'item-title',
+                                innerHTML: `<strong>${action.title}</strong>`
+                            })
+                        ),
+                        actionText('Question:'),
+                        renderScrollableContent(
+                            renderUnstyledValue(question.Text, 'Question')
+                        ),
+                        actionText('Default Answer:'),
+                        renderScrollableContent(
+                            renderUnstyledValue(question.DefaultValue, 'Default Value')
+                        )
+                    )
+                ))
+            }
+        }
+    }
+
+    return [
+        renderElement('div', {
+                className: 'block',
+                style: 'text-align:left',
+            },
+            renderElement('h3', {innerText: 'Import Questions'}),
+        ),
+        renderInsetList(...questions)
+    ];
+}
+
+export function renderScrollableContent(...content: HTMLElement[]) {
+    return renderClass('sp-scrollable-action-content', ...content)
+}
+
+interface SegmentedButton {
+    text: string
+    onclick: () => void
+}
+
+export function renderSegmentedControl(buttons: Array<SegmentedButton>) {
+    const segmented = renderElement('p', {className: 'segmented segmented-strong'});
+    for (const i in buttons) {
+        const props = buttons[i];
+        const button = renderElement('button', {
+            className: 'button',
+            innerText: props.text
+        })
+        // @ts-ignore
+        if (Number(i) === 0) {
+            button.classList.add('button-active');
+        }
+        button.onclick = () => {
+            segmented.querySelectorAll('button')?.forEach(b => b.classList.remove('button-active'));
+            button.classList.add('button-active');
+
+            if (props.onclick) {
+                button.onclick = props.onclick;
+            }
+        };
+        segmented.appendChild(button);
+    }
+    segmented.appendChild(renderElement('span', {className: 'segmented-highlight'}))
+
+    return segmented
 }
 
 enum ItemType {

--- a/src/render.ts
+++ b/src/render.ts
@@ -553,7 +553,7 @@ function renderSetupTab(shortcut: ShortcutData): HTMLElement[] {
     return [
         renderElement('div', {
                 className: 'block',
-                style: 'text-align:left',
+                style: 'text-align:left;min-width:20rem',
             },
             renderElement('h3', {innerText: 'Import Questions'}),
         ),

--- a/src/render.ts
+++ b/src/render.ts
@@ -408,17 +408,6 @@ function toggleModal() {
     }
 }
 
-function toggleTab(id: string) {
-    const tabs = document.querySelectorAll('div.tab') as NodeListOf<HTMLElement>;
-    if (tabs) {
-        tabs.forEach(t => t.style.display = 'none');
-    }
-    const tab = document.querySelector('div.tab#tab-' + id) as HTMLElement;
-    if (tab) {
-        tab.style.display = 'block';
-    }
-}
-
 export function renderDetails(shortcut: ShortcutData): void {
     container.appendChild(renderElement('div', {},
         renderElement('div', {
@@ -444,11 +433,9 @@ export function renderDetails(shortcut: ShortcutData): void {
                     renderSegmentedControl([
                         {
                             text: 'Details',
-                            onclick: () => toggleTab('details'),
                         },
                         {
                             text: 'Setup',
-                            onclick: () => toggleTab('setup'),
                         },
                     ]),
                 ),
@@ -567,7 +554,6 @@ export function renderScrollableContent(...content: HTMLElement[]) {
 
 interface SegmentedButton {
     text: string
-    onclick: () => void
 }
 
 export function renderSegmentedControl(buttons: Array<SegmentedButton>) {
@@ -586,10 +572,6 @@ export function renderSegmentedControl(buttons: Array<SegmentedButton>) {
         button.onclick = () => {
             segmented.querySelectorAll('button')?.forEach(b => b.classList.remove('button-active'));
             button.classList.add('button-active');
-
-            if (props.onclick) {
-                button.onclick = props.onclick;
-            }
         };
         segmented.appendChild(button);
     }

--- a/src/style.css
+++ b/src/style.css
@@ -29,7 +29,11 @@
         background: #141414 !important;
     }
 
-    .sp-container .card {
+    .sp-container .sp-open-details {
+        background: #333233 !important;
+    }
+
+    .sp-container .card, .sp-container .list-strong ul {
         color: white;
         background: #242323;
         border: 1px solid #373636;
@@ -111,6 +115,18 @@
 
     .sp-condition {
         border-color: #3a3a3b !important;
+    }
+
+    .sp-container .sp-modal .sp-modal-content {
+        background: #121212 !important;
+    }
+
+    .sp-container .segmented .button {
+        color: #ffffff;
+    }
+
+    .sp-container .segmented-highlight {
+        background-color: #505051 !important;
     }
 }
 
@@ -490,4 +506,32 @@
 
 .sp-action-content .sp-condition:not(:last-child) {
     border-bottom: 0.1rem solid #e6e6e6;
+}
+
+.sp-open-details {
+    position: fixed;
+    top: 0.5rem;
+    right: 0.5rem;
+    z-index: 10;
+    background: #ffffff;
+    padding: 0.5rem;
+    border-radius: 0.5rem;
+    border-right: 0.5rem;
+}
+
+/* Modal */
+.sp-modal {
+    position: fixed;
+    z-index: 20;
+    inset: 0;
+    display: none;
+    overflow-y: auto;
+    justify-content: center;
+    align-items: safe center;
+    background: rgba(50, 50, 50, .5);
+}
+
+.sp-modal-content {
+    background: #e7e7e8;
+    border-radius: 0.5rem;
 }

--- a/src/style.css
+++ b/src/style.css
@@ -125,6 +125,10 @@
         color: #ffffff;
     }
 
+    .sp-container .block-header {
+        color: #6e6e6d !important;
+    }
+
     .sp-container .segmented-highlight {
         background-color: #505051 !important;
     }

--- a/src/style.css
+++ b/src/style.css
@@ -513,9 +513,9 @@
 }
 
 .sp-open-details {
-    position: fixed;
-    top: 0.5rem;
-    right: 0.5rem;
+    position: absolute;
+    top: 1rem;
+    right: 1rem;
     z-index: 10;
     background: #ffffff;
     padding: 0.5rem;

--- a/src/style.css
+++ b/src/style.css
@@ -129,6 +129,10 @@
         color: #6e6e6d !important;
     }
 
+    .sp-container .segmented {
+        background: #363633;
+    }
+
     .sp-container .segmented-highlight {
         background-color: #505051 !important;
     }

--- a/src/value.ts
+++ b/src/value.ts
@@ -218,7 +218,7 @@ function renderInlineVariable(aggrandizements: Aggrandizement[], varName: string
         icon.classList.add(char);
     }
 
-    if (aggrandizements.length) {
+    if (aggrandizements) {
         varName += getAggrandizements(aggrandizements)
     }
 

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -14,7 +14,7 @@ export default defineConfig({
                 purgecss({
                     content: ['./src/**/*.ts'],
                     css: ['./src/style.css'],
-                    safelist: [/^c-?\d+/, /^g\d+/, /treeview/, /segmented/, /tab/]
+                    safelist: [/^c-?\d+/, /^g\d+/, /treeview/]
                 })
             ]
         }

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -14,7 +14,7 @@ export default defineConfig({
                 purgecss({
                     content: ['./src/**/*.ts'],
                     css: ['./src/style.css'],
-                    safelist: [/^c-?\d+/, /^g\d+/, /treeview?.+/, /segmented?.+/, /tabs?.+/]
+                    safelist: [/^c-?\d+/, /^g\d+/, /treeview/, /segmented/, /tab/]
                 })
             ]
         }

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -14,7 +14,7 @@ export default defineConfig({
                 purgecss({
                     content: ['./src/**/*.ts'],
                     css: ['./src/style.css'],
-                    safelist: [/^c-?\d+/, /^g\d+/, /^treeview.+/]
+                    safelist: [/^c-?\d+/, /^g\d+/, /^treeview.+/, /^segmented.+/, /^tab(s)?.+/]
                 })
             ]
         }

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -14,7 +14,7 @@ export default defineConfig({
                 purgecss({
                     content: ['./src/**/*.ts'],
                     css: ['./src/style.css'],
-                    safelist: [/^c-?\d+/, /^g\d+/, /treeview.+/, /segmented.+/, /tab.+/]
+                    safelist: [/^c-?\d+/, /^g\d+/, /treeview?.+/, /segmented?.+/, /tabs?.+/]
                 })
             ]
         }

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -14,7 +14,7 @@ export default defineConfig({
                 purgecss({
                     content: ['./src/**/*.ts'],
                     css: ['./src/style.css'],
-                    safelist: [/^c-?\d+/, /^g\d+/, /^treeview.+/, /^segmented.+/, /^tab(s)?.+/]
+                    safelist: [/^c-?\d+/, /^g\d+/, /treeview.+/, /segmented.+/, /tab.+/]
                 })
             ]
         }


### PR DESCRIPTION
This implements an info circle fixed at the top of the Shortcut preview that, when clicked, pops a modal that, for now, is custom.

This implements the Details and Setup tabs with segmented controls all functionality of which provided by Framework7, with some needing some dark mode holes patched up.

## Details tab

Shows where the Shortcut will show up:

<img width="382" alt="Screenshot 2025-04-28 at 23 02 57" src="https://github.com/user-attachments/assets/20314d54-9eab-438a-b012-7c994684b53b" />

## Setup Tab

Shows import questions and their default answers

<img width="762" alt="Screenshot 2025-04-28 at 23 03 17" src="https://github.com/user-attachments/assets/11e78c6c-263d-4644-b8ed-8e3b2df604e7" />

## Dark Mode Support

<img width="386" alt="Screenshot 2025-04-28 at 23 02 26" src="https://github.com/user-attachments/assets/ea1a4ebb-4fee-41f5-b83d-f590b28ccda7" />

<img width="757" alt="Screenshot 2025-04-28 at 23 02 34" src="https://github.com/user-attachments/assets/5a2f01c7-3508-4dfe-b68e-41a62b430333" />